### PR TITLE
Adjust GCS filter false positive rate based on number of elements.

### DIFF
--- a/gcs/builder/builder.go
+++ b/gcs/builder/builder.go
@@ -337,6 +337,12 @@ func BuildBasicFilter(block *wire.MsgBlock, prevOutScripts [][]byte) (*gcs.Filte
 		b.AddEntry(prevScript)
 	}
 
+	// Adjust the filter false positive rate
+	fpScaleFactor := float64(len(b.data)) / float64(gcs.TargetElements)
+	if fpScaleFactor > 1 {
+		b.m = uint64(float64(b.m) * fpScaleFactor)
+	}
+
 	return b.Build()
 }
 

--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -35,6 +35,12 @@ const (
 	// varIntProtoVer is the protocol version to use for serializing N as a
 	// VarInt.
 	varIntProtoVer uint32 = 0
+
+	// TargetElements is roughly the number of elements expected
+	// in a 1 MB block. We use this number to calculate how many times
+	// larger the actual number of elements inserted into the filter is
+	// so that we can adjust the filter false positive rate accordingly.
+	TargetElements = 8000
 )
 
 // fastReduction calculates a mapping that's more ore less equivalent to: x mod
@@ -208,6 +214,10 @@ func FromNBytes(P uint8, M uint64, d []byte) (*Filter, error) {
 	}
 	if N >= (1 << 32) {
 		return nil, ErrNTooBig
+	}
+	fpScaleFactor := float64(N) / float64(TargetElements)
+	if fpScaleFactor > 1 {
+		M = uint64(float64(M) * fpScaleFactor)
 	}
 	return FromBytes(uint32(N), P, M, buffer.Bytes())
 }


### PR DESCRIPTION
The current GCS filter code is really designed exclusively for 1MB blocks. As
the number of elements in the filter goes up the false positive rate of the filter
goes up. The end result would be that filters for larger blocks would have a very
high false positive rate and trigger neutrino wallets to download nearly all blocks. 

The default m value is 784931 which means 1 false positive in every 784931 filter elements. 

This commit adjusts the GCS filter m value upwards to ensure a consistent false
positive rate as the number of elements in the filter grows. I've selected 8,000
as the target base value as that roughly corresponds to a 1MB block containing 2,000
transactions with an average of two inputs and two outputs per tranaction. This
number may be an over estimate for the number of elements in a 1 MB block as a
block often contains multipe outputs paying the same script or spending from the
same script. In such cases the script is only added to the filter once.

Thus this commit ensures the m value will never be less than 784931 but can go
higher as the number of non-duplicate elements in the block increases.