### PR TITLE
Fix filtering blocks when using CTOR

### DIFF
--- a/bloom/merkleblock_test.go
+++ b/bloom/merkleblock_test.go
@@ -7,6 +7,7 @@ package bloom_test
 import (
 	"bytes"
 	"encoding/hex"
+	"github.com/gcash/bchd/chaincfg"
 	"testing"
 
 	"github.com/gcash/bchd/chaincfg/chainhash"
@@ -70,5 +71,38 @@ func TestMerkleBlock3(t *testing.T) {
 		t.Errorf("TestMerkleBlock3 failed merkle block comparison: "+
 			"got %v want %v", got.Bytes(), want)
 		return
+	}
+}
+
+func TestMerkleBlockOutOfOrder(t *testing.T) {
+	blockStr := `0100000050120119172a610421a6c3011dd330d9df07b63616c2cc1f1cd00200000000006657a9252aacd5c0b2940996ecff952228c3067cc38d4885efb5a4ac4247e9f337221b4d4c86041b0f2b5710030100000001c40297f730dd7b5a99567eb8d27b78758f607507c52292d02d4031895b52f2ff010000008a4730440220032d30df5ee6f57fa46cddb5eb8d0d9fe8de6b342d27942ae90a3231e0ba333e02203deee8060fdc70230a7f5b4ad7d7bc3e628cbe219a886b84269eaeb81e26b4fe014104ae31c31bf91278d99b8377a35bbce5b27d9fff15456839e919453fc7b3f721f0ba403ff96c9deeb680e5fd341c0fc3a7b90da4631ee39560639db462e9cb850fffffffff0240420f00000000001976a914b0dcbf97eabf4404e31d952477ce822dadbe7e1088acc060d211000000001976a9146b1281eec25ab4e1e0793ff4e08ab1abb3409cd988ac000000000100000001c40297f730dd7b5a99567eb8d27b78758f607507c52292d02d4031895b52f2ff000000008a4730440220032d30df5ee6f57fa46cddb5eb8d0d9fe8de6b342d27942ae90a3231e0ba333e02203deee8060fdc70230a7f5b4ad7d7bc3e628cbe219a886b84269eaeb81e26b4fe014104ae31c31bf91278d99b8377a35bbce5b27d9fff15456839e919453fc7b3f721f0ba403ff96c9deeb680e5fd341c0fc3a7b90da4631ee39560639db462e9cb850fffffffff0240420f00000000001976a914b0dcbf97eabf4404e31d952477ce822dadbe7e1088acc060d211000000001976a9146b1281eec25ab4e1e0793ff4e08ab1abb3409cd988ac000000000100000001032e38e9c0a84c6046d687d10556dcacc41d275ec55fc00779ac88fdf357a187000000008c493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3ffffffff0200e32321000000001976a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac000fe208010000001976a914948c765a6914d43f2a7ac177da2c2f6b52de3d7c88ac00000000`
+	blockBytes, err := hex.DecodeString(blockStr)
+	if err != nil {
+		t.Errorf("TestMerkleBlock3 DecodeString failed: %v", err)
+		return
+	}
+	blk, err := bchutil.NewBlockFromBytes(blockBytes)
+	if err != nil {
+		t.Errorf("TestMerkleBlock3 NewBlockFromBytes failed: %v", err)
+		return
+	}
+
+	f := bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+
+	addr, err := bchutil.DecodeAddress("qz2gcaj6dy2dg0e20tqh0k3v9a449h3a0s8t2kgggp", &chaincfg.SimNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr2, err := bchutil.DecodeAddress("qrpe3mafcwft5cqnchsyaeefw4000avtxg7jh5geku", &chaincfg.SimNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.Add(addr.ScriptAddress())
+	f.Add(addr2.ScriptAddress())
+
+	mBlock, _ := bloom.NewMerkleBlock(blk, f)
+	if mBlock.Transactions != 3 {
+		t.Fatalf("Returned incorrect number of transactions. Expected %d, got %d", 3, mBlock.Transactions)
 	}
 }

--- a/merkleblock/encode.go
+++ b/merkleblock/encode.go
@@ -101,10 +101,10 @@ func NewMerkleBlockWithFilter(block *bchutil.Block, filter *bloom.Filter) (*wire
 		matchedBits: make([]byte, 0, numTx),
 	}
 
-	// Find and keep track of any transactions that match the filter.
+	matchedMap := bloom.GetMatchedIndices(block, filter)
 	var matchedIndices []uint32
 	for txIndex, tx := range block.Transactions() {
-		if filter.MatchTxAndUpdate(tx) {
+		if matchedMap[txIndex] {
 			mBlock.matchedBits = append(mBlock.matchedBits, 0x01)
 			matchedIndices = append(matchedIndices, uint32(txIndex))
 		} else {

--- a/merkleblock/encode_test.go
+++ b/merkleblock/encode_test.go
@@ -8,6 +8,7 @@ package merkleblock_test
 import (
 	"bytes"
 	"encoding/hex"
+	"github.com/gcash/bchd/chaincfg"
 	"testing"
 
 	"github.com/gcash/bchd/chaincfg/chainhash"
@@ -75,6 +76,39 @@ func TestNewMerkleBlockWithFilter(t *testing.T) {
 		t.Errorf("TestMerkleBlock3 failed merkle proof comparison: "+
 			"got %v want %v", got.Bytes(), want)
 		return
+	}
+}
+
+func TestMerkleBlockOutOfOrder(t *testing.T) {
+	blockStr := `0100000050120119172a610421a6c3011dd330d9df07b63616c2cc1f1cd00200000000006657a9252aacd5c0b2940996ecff952228c3067cc38d4885efb5a4ac4247e9f337221b4d4c86041b0f2b5710030100000001c40297f730dd7b5a99567eb8d27b78758f607507c52292d02d4031895b52f2ff010000008a4730440220032d30df5ee6f57fa46cddb5eb8d0d9fe8de6b342d27942ae90a3231e0ba333e02203deee8060fdc70230a7f5b4ad7d7bc3e628cbe219a886b84269eaeb81e26b4fe014104ae31c31bf91278d99b8377a35bbce5b27d9fff15456839e919453fc7b3f721f0ba403ff96c9deeb680e5fd341c0fc3a7b90da4631ee39560639db462e9cb850fffffffff0240420f00000000001976a914b0dcbf97eabf4404e31d952477ce822dadbe7e1088acc060d211000000001976a9146b1281eec25ab4e1e0793ff4e08ab1abb3409cd988ac000000000100000001c40297f730dd7b5a99567eb8d27b78758f607507c52292d02d4031895b52f2ff000000008a4730440220032d30df5ee6f57fa46cddb5eb8d0d9fe8de6b342d27942ae90a3231e0ba333e02203deee8060fdc70230a7f5b4ad7d7bc3e628cbe219a886b84269eaeb81e26b4fe014104ae31c31bf91278d99b8377a35bbce5b27d9fff15456839e919453fc7b3f721f0ba403ff96c9deeb680e5fd341c0fc3a7b90da4631ee39560639db462e9cb850fffffffff0240420f00000000001976a914b0dcbf97eabf4404e31d952477ce822dadbe7e1088acc060d211000000001976a9146b1281eec25ab4e1e0793ff4e08ab1abb3409cd988ac000000000100000001032e38e9c0a84c6046d687d10556dcacc41d275ec55fc00779ac88fdf357a187000000008c493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3ffffffff0200e32321000000001976a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac000fe208010000001976a914948c765a6914d43f2a7ac177da2c2f6b52de3d7c88ac00000000`
+	blockBytes, err := hex.DecodeString(blockStr)
+	if err != nil {
+		t.Errorf("TestMerkleBlock3 DecodeString failed: %v", err)
+		return
+	}
+	blk, err := bchutil.NewBlockFromBytes(blockBytes)
+	if err != nil {
+		t.Errorf("TestMerkleBlock3 NewBlockFromBytes failed: %v", err)
+		return
+	}
+
+	f := bloom.NewFilter(10, 0, 0.000001, wire.BloomUpdateAll)
+
+	addr, err := bchutil.DecodeAddress("qz2gcaj6dy2dg0e20tqh0k3v9a449h3a0s8t2kgggp", &chaincfg.SimNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr2, err := bchutil.DecodeAddress("qrpe3mafcwft5cqnchsyaeefw4000avtxg7jh5geku", &chaincfg.SimNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.Add(addr.ScriptAddress())
+	f.Add(addr2.ScriptAddress())
+
+	mBlock, _ := merkleblock.NewMerkleBlockWithFilter(blk, f)
+	if mBlock.Transactions != 3 {
+		t.Fatalf("Returned incorrect number of transactions. Expected %d, got %d", 3, mBlock.Transactions)
 	}
 }
 


### PR DESCRIPTION
There is a bug where the bloom filter will fail to match if the dependent transaction
appears after a child due to CTOR. This commit fixes the bug.

closes #13 