### PR TITLE
Remove OP_RETURN from GCS filter

### DIFF
--- a/gcs/builder/builder.go
+++ b/gcs/builder/builder.go
@@ -12,7 +12,6 @@ import (
 	"math"
 
 	"github.com/gcash/bchd/chaincfg/chainhash"
-	"github.com/gcash/bchd/txscript"
 	"github.com/gcash/bchd/wire"
 	"github.com/gcash/bchutil/gcs"
 )
@@ -332,24 +331,6 @@ func buildBasicFilterWithKey(block *wire.MsgBlock, key chainhash.Hash) (*gcs.Fil
 		// For each output in a transaction, we'll add each pkScript.
 		for _, txOut := range tx.TxOut {
 			if len(txOut.PkScript) == 0 {
-				continue
-			}
-
-			// In order to allow the filters to later be committed
-			// to within an OP_RETURN output, we ignore all OP_RETURNs
-			// in the coinbase to avoid a circular dependency.
-			if i == 0 && txOut.PkScript[0] == txscript.OP_RETURN {
-				continue
-			}
-
-			// If this is a non-coinbase OP_RETURN output then add all
-			// the data elements in the script.
-			if txOut.PkScript[0] == txscript.OP_RETURN {
-				dataElements, err := txscript.ExtractDataElements(txOut.PkScript)
-				if err != nil {
-					continue
-				}
-				b.AddEntries(dataElements)
 				continue
 			}
 

--- a/gcs/builder/builder_test.go
+++ b/gcs/builder/builder_test.go
@@ -309,29 +309,6 @@ func TestBuildBasicFilter(t *testing.T) {
 			}
 		}
 	}
-
-	// Test OP_RETURN
-	matches, err = filter.Match(key, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x09, 0x09})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !matches {
-		t.Error("OP_RETURN data element 0 does not match the filter")
-	}
-	matches, err = filter.Match(key, []byte{0xff, 0xff, 0xff, 0xff})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !matches {
-		t.Error("OP_RETURN data element 1 does not match the filter")
-	}
-	matches, err = filter.Match(key, []byte{0x07})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if matches {
-		t.Error("OP_RETURN data element 2 matches the filter when it should not")
-	}
 }
 
 var TestBlock = wire.MsgBlock{

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,7 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/goclean.sh
+++ b/goclean.sh
@@ -22,6 +22,5 @@ test -z "$(golangci-lint run --disable-all \
 --enable=golint \
 --enable=vet \
 --enable=gosimple \
---enable=unconvert \
---deadline=10m | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
+--enable=unconvert | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
 go test ./...


### PR DESCRIPTION
Bitcoin Cash is not currently using OP_RETURN for anything in a way that would
be able to make use of having it in the CF Filters. For this reason we are
removing it and making the filters smaller and the spec simpiler.