### PR TITLE
Fix DecodeAddress issue with legacy testnet P2SH address

### DIFF
--- a/address.go
+++ b/address.go
@@ -86,6 +86,8 @@ func DecodeAddress(addr string, defaultNet *chaincfg.Params) (Address, error) {
 		addrWithPrefix = pre + ":" + strings.ToLower(addr) // so we don't mix cases
 	}
 
+	var cashaddrErr error
+
 	// Switch on decoded length to determine the type.
 	decoded, _, typ, err := checkDecodeCashAddress(addrWithPrefix)
 	if err == nil {
@@ -103,7 +105,7 @@ func DecodeAddress(addr string, defaultNet *chaincfg.Params) (Address, error) {
 			return nil, errors.New("decoded address is of unknown size")
 		}
 	} else if err == ErrChecksumMismatch {
-		return nil, ErrChecksumMismatch
+		cashaddrErr = ErrChecksumMismatch
 	}
 
 	// Serialized public keys are either 65 bytes (130 hex chars) if
@@ -121,6 +123,9 @@ func DecodeAddress(addr string, defaultNet *chaincfg.Params) (Address, error) {
 	if err != nil {
 		if err == base58.ErrChecksum {
 			return nil, ErrChecksumMismatch
+		}
+		if cashaddrErr != nil {
+			return nil, cashaddrErr
 		}
 		return nil, errors.New("decoded address is of unknown format")
 	}

--- a/address_test.go
+++ b/address_test.go
@@ -300,7 +300,6 @@ func TestAddresses(t *testing.T) {
 			net: &chaincfg.TestNet3Params,
 		},
 		{
-			// Taken from bitcoind base58_keys_valid.
 			name:    "legacy testnet p2sh (reported issue)",
 			addr:    "2MscXFWM3yfDTYxGGC2dXCZvcMd6ySyqgPt",
 			encoded: "2MscXFWM3yfDTYxGGC2dXCZvcMd6ySyqgPt",

--- a/address_test.go
+++ b/address_test.go
@@ -299,7 +299,25 @@ func TestAddresses(t *testing.T) {
 			},
 			net: &chaincfg.TestNet3Params,
 		},
-
+		{
+			// Taken from bitcoind base58_keys_valid.
+			name:    "legacy testnet p2sh (reported issue)",
+			addr:    "2MscXFWM3yfDTYxGGC2dXCZvcMd6ySyqgPt",
+			encoded: "2MscXFWM3yfDTYxGGC2dXCZvcMd6ySyqgPt",
+			valid:   true,
+			result: bchutil.TstLegacyAddressScriptHash(
+				[ripemd160.Size]byte{
+					0x4, 0x7, 0x25, 0x2a, 0x3a, 0x2e, 0xb1, 0x5c, 0x8f, 0xc1,
+					0x8d, 0xf4, 0xd, 0xf0, 0x5b, 0x34, 0xc8, 0xfe, 0x9e, 0x11},
+				chaincfg.TestNet3Params.LegacyScriptHashAddrID),
+			f: func() (bchutil.Address, error) {
+				hash := []byte{
+					0x4, 0x7, 0x25, 0x2a, 0x3a, 0x2e, 0xb1, 0x5c, 0x8f, 0xc1,
+					0x8d, 0xf4, 0xd, 0xf0, 0x5b, 0x34, 0xc8, 0xfe, 0x9e, 0x11}
+				return bchutil.NewLegacyAddressScriptHashFromHash(hash, &chaincfg.TestNet3Params)
+			},
+			net: &chaincfg.TestNet3Params,
+		},
 		// Negative legacy P2SH tests.
 		{
 			name:  "legacy p2sh wrong hash length",


### PR DESCRIPTION
Fixes: https://github.com/gcash/bchd/issues/331