### PR TITLE
DecodeAddress update for slp

### DIFF
--- a/address.go
+++ b/address.go
@@ -36,6 +36,10 @@ var (
 
 	// ErrInvalidFormat describes an error where decoding failed due to invalid version
 	ErrInvalidFormat = errors.New("invalid format: version and/or checksum bytes missing")
+
+	// ErrUnknownFormat describes an error that occurs when an address cannot be
+	// decoded because it has an unknown format.
+	ErrUnknownFormat = errors.New("decoded address is of unknown format")
 )
 
 // Address is an interface type for any type of destination a transaction
@@ -109,7 +113,7 @@ func DecodeAddress(addr string, defaultNet *chaincfg.Params) (Address, error) {
 
 		// try to decode with slp prefix instead
 		addrWithPrefix := addr
-		if !strings.EqualFold(addr[:len(slpPrefix)+1], slpPrefix+":") {
+		if !strings.EqualFold(addr[:len(bchPrefix)+1], bchPrefix+":") && !strings.EqualFold(addr[:len(slpPrefix)+1], slpPrefix+":") {
 			addrWithPrefix = slpPrefix + ":" + strings.ToLower(addr) // so we don't mix cases
 		}
 
@@ -153,7 +157,7 @@ func DecodeAddress(addr string, defaultNet *chaincfg.Params) (Address, error) {
 		if cashaddrErr != nil {
 			return nil, cashaddrErr
 		}
-		return nil, errors.New("decoded address is of unknown format")
+		return nil, ErrUnknownFormat
 	}
 	switch len(decoded) {
 	case ripemd160.Size: // P2PKH or P2SH

--- a/address_test.go
+++ b/address_test.go
@@ -854,6 +854,24 @@ func TestDecodeAddressSlpMainnetWithPrefix(t *testing.T) {
 	}
 }
 
+func TestDecodeAddressSlpMainnetWithWrongPrefix(t *testing.T) {
+	prefix := "bitcoincash"
+	slpAddrStr := "qrkjty23a5yl7vcvcnyh4dpnxxzuzs4lzqvesp65yq"
+	_, err := bchutil.DecodeAddress(prefix+":"+slpAddrStr, &chaincfg.MainNetParams)
+	if err != bchutil.ErrChecksumMismatch {
+		t.Fatal(err)
+	}
+}
+
+func TestDecodeAddressSlpMainnetWithUnknownPrefix(t *testing.T) {
+	prefix := "xyz"
+	slpAddrStr := "qrkjty23a5yl7vcvcnyh4dpnxxzuzs4lzqvesp65yq"
+	_, err := bchutil.DecodeAddress(prefix+":"+slpAddrStr, &chaincfg.MainNetParams)
+	if err != bchutil.ErrUnknownFormat {
+		t.Fatal(err)
+	}
+}
+
 func TestDecodeAddressSlpMainnetUpperCase(t *testing.T) {
 	slpAddrStr := "QRKJTY23A5YL7VCVCNYH4DPNXXZUZS4LZQVESP65YQ"
 	addr, err := bchutil.DecodeAddress(slpAddrStr, &chaincfg.MainNetParams)
@@ -874,6 +892,15 @@ func TestDecodeAddressSlpMainnetWithPrefixUpper(t *testing.T) {
 	}
 	if addr.String() != strings.ToLower(slpAddrStr) {
 		t.Fatal("decode failed")
+	}
+}
+
+func TestDecodeAddressSlpMainnetWithPrefixUpperWrongPrefix(t *testing.T) {
+	prefix := "BITCOINCASH"
+	slpAddrStr := "QRKJTY23A5YL7VCVCNYH4DPNXXZUZS4LZQVESP65YQ"
+	_, err := bchutil.DecodeAddress(prefix+":"+slpAddrStr, &chaincfg.MainNetParams)
+	if err != bchutil.ErrChecksumMismatch {
+		t.Fatal(err)
 	}
 }
 

--- a/address_test.go
+++ b/address_test.go
@@ -842,9 +842,33 @@ func TestDecodeAddressSlpMainnet(t *testing.T) {
 	}
 }
 
+func TestDecodeAddressSlpMainnetWithPrefix(t *testing.T) {
+	prefix := "simpleledger"
+	slpAddrStr := "qrkjty23a5yl7vcvcnyh4dpnxxzuzs4lzqvesp65yq"
+	addr, err := bchutil.DecodeAddress(prefix+":"+slpAddrStr, &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr.String() != slpAddrStr {
+		t.Fatal("decode failed")
+	}
+}
+
 func TestDecodeAddressSlpMainnetUpperCase(t *testing.T) {
 	slpAddrStr := "QRKJTY23A5YL7VCVCNYH4DPNXXZUZS4LZQVESP65YQ"
 	addr, err := bchutil.DecodeAddress(slpAddrStr, &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr.String() != strings.ToLower(slpAddrStr) {
+		t.Fatal("decode failed")
+	}
+}
+
+func TestDecodeAddressSlpMainnetWithPrefixUpper(t *testing.T) {
+	prefix := "SIMPLELEDGER"
+	slpAddrStr := "QRKJTY23A5YL7VCVCNYH4DPNXXZUZS4LZQVESP65YQ"
+	addr, err := bchutil.DecodeAddress(prefix+":"+slpAddrStr, &chaincfg.MainNetParams)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This method needs to be able to handle the case where a user includes an address string with the slp address prefix.  

PR #24 mistakenly missed this because I wasn't able to test it out with bchd due to golang dependency errors when trying to compile with my own local version of bchutil.